### PR TITLE
Support proxy file drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2020-12-02
+- Add support for proxy file drop.
+
 ## [0.0.3] - 2020-10-30
 - Add ability to customize HTML rendered in Dropzone.
 

--- a/lib/dropzone_input/helpers.rb
+++ b/lib/dropzone_input/helpers.rb
@@ -12,7 +12,7 @@ module DropzoneInput
         controller: 'dropzone',
         dropzone_accepted_files: ActiveStorage.variable_content_types.join(',')
       }
-      %i( max_files max_file_size file_success_event queue_complete_event ).each do |key|
+      %i( max_files max_file_size file_drop_event file_success_event queue_complete_event file_drop_id file_drop_over_id ).each do |key|
         data["dropzone_#{key}".to_sym] = options.delete(key) if options.key?(key)
       end
 

--- a/lib/dropzone_input/version.rb
+++ b/lib/dropzone_input/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DropzoneInput
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darkroom-com/dropzone-input",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A stimulus.js based controller to add dropzone support to Rails forms",
   "main": "dist/index.js",
   "umd:main": "dist/index.umd.js",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-eslint": "^10.1.0",
     "dropzone": "^5.7.1",
     "eslint": "^7.4.0",
-    "rollup": "^2.19.0",
+    "rollup": "^2.33.1",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-filesize": "^9.0.2",
     "rollup-plugin-node-resolve": "^5.2.0",
@@ -44,8 +44,8 @@
   },
   "peerDependencies": {
     "@rails/activestorage": "^6.0.0",
-    "stimulus": "^1.1.1",
-    "dropzone": "^5.5.1"
+    "dropzone": "^5.5.1",
+    "stimulus": "^1.1.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,11 @@ class DropzoneController extends Controller {
     }
   }
 
+  resetDragCounter() {
+    this.dragCounter = 0;
+    this.handleFileDropDragLeave();
+  }
+
   bindFileDrop() {
     this.dragCounter = 0;
 
@@ -110,6 +115,7 @@ class DropzoneController extends Controller {
         if (e.dataTransfer && e.dataTransfer.files.length) {
           this.dropzone.drop({ dataTransfer: e.dataTransfer });
         }
+        this.resetDragCounter();
       });
 
       this.fileDropOver = document.getElementById(this.fileDropOverId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3484,10 +3484,10 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.19.0:
-  version "2.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.32.1.tgz#625a92c54f5b4d28ada12d618641491d4dbb548c"
-  integrity sha512-Op2vWTpvK7t6/Qnm1TTh7VjEZZkN8RWgf0DHbkKzQBwNf748YhXbozHVefqpPp/Fuyk/PQPAnYsBxAEtlMvpUw==
+rollup@^2.33.1:
+  version "2.33.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.33.1.tgz#802795164164ee63cd47769d8879c33ec8ae0c40"
+  integrity sha512-uY4O/IoL9oNW8MMcbA5hcOaz6tZTMIh7qJHx/tzIJm+n1wLoY38BLn6fuy7DhR57oNFLMbDQtDeJoFURt5933w==
   optionalDependencies:
     fsevents "~2.1.2"
 


### PR DESCRIPTION
Support file dropping through an (proxy) element

Add these params to your `<%= dropzone %>`:

```
file_drop_id: 'drop',
file_drop_over_id: 'dropOver',
file_drop_event: 'FILE_DROP',
```

`file_drop_id`: the proxy DOM element 
`file_drop_over_id`: optional element to hide/show while dragging over
`file_drop_event`: event triggered on file(s) drop

