### PR TITLE
Parallel uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.bundle
 dist
 node_modules
 vendor/bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.0] - 2021-02-12
-- Comply to `parallel-uploads`
+## [1.2.0] - 2021-02-15
+- Add `parallel-uploads`, `file-start-event`
 - Prevent duplicate files from being added
 
 ## [1.1.1] - 2021-02-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2021-02-12
+- Comply to `parallel-uploads`
+- Prevent duplicate files from being added
+
 ## [1.1.1] - 2021-02-12
 - Prevent duplicate binding
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ A Rails helper and Stimulus Controller that makes adding dropzone to a Rails for
 specific styles, etc) will be non-configurable at the moment. We will work to generalize this over
 time and *pull requests are welcome* and will be reviewed quickly.
 
+## Options & Events
+
+| Option Name | Description |
+| -- | -- |
+| max_files | default: `null` |
+| max_file_size | default: `null` |
+| parallel_uploads | default: `2` |
+
+Events below receive `file` as first parameter.
+
+| Event Name | Description |
+| -- | -- |
+| file_added_event | File added to queue |
+| file_progress_event | Periodically called while file is being uploaded. `progress` in the second parameter, or through the `upload` property: `file.upload.progress`, `file.upload.bytesSent` |
+| file_removed_event | File removed from queue |
+| file_start_event | File will start uploading |
+| file_success_event | File successfully uploaded |
+
 ## Installation
 
 Add to your Gemfile.

--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ time and *pull requests are welcome* and will be reviewed quickly.
 
 | Option Name | Description |
 | -- | -- |
-| max_files | default: `null` |
-| max_file_size | default: `null` |
-| parallel_uploads | default: `2` |
+| `max_files` | default: `null` |
+| `max_file_size` | default: `null` |
+| `parallel_uploads` | default: `2` |
 
 Events below receive `file` as first parameter.
 
 | Event Name | Description |
 | -- | -- |
-| file_added_event | File added to queue |
-| file_progress_event | Periodically called while file is being uploaded. `progress` in the second parameter, or through the `upload` property: `file.upload.progress`, `file.upload.bytesSent` |
-| file_removed_event | File removed from queue |
-| file_start_event | File will start uploading |
-| file_success_event | File successfully uploaded |
+| `file_added_event` | File added to queue |
+| `file_progress_event` | Periodically called while file is being uploaded. `progress` in the second parameter, or through the `upload` property: `file.upload.progress`, `file.upload.bytesSent` |
+| `file_removed_event` | File removed from queue |
+| `file_start_event` | File will start uploading |
+| `file_success_event` | File successfully uploaded |
 
 ## Installation
 

--- a/lib/dropzone_input/helpers.rb
+++ b/lib/dropzone_input/helpers.rb
@@ -21,6 +21,7 @@ module DropzoneInput
         file_drop_over_id
         file_progress_event
         file_removed_event
+        file_start_event
         file_success_event
         parallel_uploads
         queue_complete_event

--- a/lib/dropzone_input/helpers.rb
+++ b/lib/dropzone_input/helpers.rb
@@ -16,13 +16,14 @@ module DropzoneInput
         max_files
         max_file_size
         file_added_event
-        file_removed_event
         file_drop_event
-        file_progress_event
-        file_success_event
-        queue_complete_event
         file_drop_id
         file_drop_over_id
+        file_progress_event
+        file_removed_event
+        file_success_event
+        parallel_uploads
+        queue_complete_event
       ).each do |key|
         data["dropzone_#{key}".to_sym] = options.delete(key) if options.key?(key)
       end

--- a/lib/dropzone_input/version.rb
+++ b/lib/dropzone_input/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DropzoneInput
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darkroom-com/dropzone-input",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A stimulus.js based controller to add dropzone support to Rails forms",
   "main": "dist/index.js",
   "umd:main": "dist/index.umd.js",

--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,7 @@ class DropzoneController extends Controller {
   runUploadQueue() {
     this.queue.forEach((controller, index, queue) => {
       if (this.uploadsInProgress < this.parallelUploads) {
+        this.dispatchEvent(this.fileStartEvent, { detail: { file: controller.file }});
         controller.start();
         queue.splice(index, 1);
         this.uploadsInProgress++;
@@ -203,6 +204,10 @@ class DropzoneController extends Controller {
 
   get fileDropEvent() {
     return this.data.get("file-drop-event");
+  }
+
+  get fileStartEvent() {
+    return this.data.get("file-start-event");
   }
 
   get fileSuccessEvent() {

--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,6 @@ class DropzoneController extends Controller {
   }
 
   runUploadQueue() {
-    console.log("runUploadQueue", this.uploadsInProgress)
     this.queue.forEach((controller, index, queue) => {
       if (this.uploadsInProgress < this.parallelUploads) {
         controller.start();

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,11 @@ class DropzoneController extends Controller {
 
   handleFileAdded(file) {
     if (file.accepted) {
+      if (this.fileExists(file)) {
+        this.dropzone.removeFile(file);
+        return;
+      }
+
       this.dispatchEvent(this.fileAddedEvent, { detail: { file: file }});
 
       const controller = new DirectUploadController(this, file);
@@ -148,6 +153,11 @@ class DropzoneController extends Controller {
       const event = new CustomEvent(eventName, info);
       window.dispatchEvent(event);
     }
+  }
+
+  fileExists(theFile) {
+    const files = this.dropzone.files.filter(file => (file.name == theFile.name && file.size == theFile.size));
+    return files.length > 1;
   }
 
   removeFromQueue(file) {

--- a/src/index.js
+++ b/src/index.js
@@ -86,12 +86,13 @@ class DropzoneController extends Controller {
       if (file.controller.xhr) {
         file.controller.xhr.abort();
         this.uploadsInProgress--;
+      } else {
+        this.removeFromQueue(file);
       }
 
       file.controller.removeHiddenInput();
 
       this.dispatchEvent(this.fileRemovedEvent, { detail: { file: file }});
-      this.removeFromQueue(file);
       this.runUploadQueue();
     }
   }


### PR DESCRIPTION
Comply to `parallel-uploads` when uploading multiple files simultaneously

Instead of initiating uploads immediately, we queue added files ensuring the number of simultaneous uploads do not exceed `parallel-uploads`

Also added `file-start-event`, which is called before the file begins uploading.