### PR TITLE
Tiff support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2021-03-02
+- Add TIFF support for thumbnails
+
 ## [1.3.0] - 2021-02-25
 - Add `max-thumbnail-file-size` option
 

--- a/lib/dropzone_input/version.rb
+++ b/lib/dropzone_input/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DropzoneInput
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-filesize": "^9.0.2",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "stimulus": "^2.0.0"
+    "stimulus": "^2.0.0",
+    "utif": "^3.1.0"
   },
   "peerDependencies": {
     "@rails/activestorage": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darkroom-com/dropzone-input",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A stimulus.js based controller to add dropzone support to Rails forms",
   "main": "dist/index.js",
   "umd:main": "dist/index.umd.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ const name = pkg.name;
 
 export default {
   input: "src/index.js",
-  external: ["stimulus", "dropzone", "@rails/activestorage"],
+  external: ["stimulus", "dropzone", "@rails/activestorage", "utif"],
   output: [
     {
       file: "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -125,21 +125,19 @@ class DropzoneController extends Controller {
   }
 
   createTiffThumbnail(file, callback) {
-    const self = this;
-
     tiffToPNG(file, (dataURL) => {
       const img = document.createElement("img");
       img.onload = () => {
         const fileObj = { width: img.width, height: img.height, dataURL: dataURL };
 
-        self.dropzone.createThumbnailFromUrl(
+        this.dropzone.createThumbnailFromUrl(
           fileObj,
-          self.dropzone.options.thumbnailWidth,
-          self.dropzone.options.thumbnailHeight,
-          self.dropzone.options.thumbnailMethod,
+          this.dropzone.options.thumbnailWidth,
+          this.dropzone.options.thumbnailHeight,
+          this.dropzone.options.thumbnailMethod,
           true,
           (thumbnail) => {
-            self.dropzone.emit("thumbnail", file, thumbnail);
+            this.dropzone.emit("thumbnail", file, thumbnail);
 
             if (callback != null) {
               callback(file);

--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,7 @@ class DropzoneController extends Controller {
         return;
       }
 
-      const isTiff = file.type === "image/tiff";
-      if (isTiff) {
+      if (file.type === "image/tiff") {
         this.createTiffThumbnail(file, file => this.fileAdded(file));
       } else {
         this.fileAdded(file);

--- a/src/tiff.js
+++ b/src/tiff.js
@@ -1,0 +1,33 @@
+import UTIF from "utif";
+
+function tiffToPNG(file, callback) {
+  const reader = new FileReader();
+
+  reader.onload = function (event) {
+    const buffer = event.target.result;
+
+    const imageFileDirs = UTIF.decode(buffer);
+    const imageRef = imageFileDirs[0];
+    UTIF.decodeImage(buffer, imageRef);
+    const rgba  = UTIF.toRGBA8(imageRef);
+    const array = new Uint8ClampedArray(rgba);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = imageRef.width;
+    canvas.height = imageRef.height;
+
+    const ctx = canvas.getContext("2d");
+    const imageData = new ImageData(array, imageRef.width, imageRef.height);
+    ctx.putImageData(imageData, 0, 0)
+
+    const dataURL = canvas.toDataURL("image/png");
+
+    if (callback != null) {
+      callback(dataURL);
+    }
+  }
+
+  reader.readAsArrayBuffer(file);
+}
+
+export { tiffToPNG };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3139,6 +3139,11 @@ pacote@^11.1.10:
     ssri "^8.0.0"
     tar "^6.0.1"
 
+pako@^1.0.5:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -4006,6 +4011,13 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utif@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/utif/-/utif-3.1.0.tgz#4abec2f5d9cafe7813c0191e007927c125401f1c"
+  integrity sha512-WEo4D/xOvFW53K5f5QTaTbbiORcm2/pCL9P6qmJnup+17eYfKaEhDeX9PeQkuyEoIxlbGklDuGl8xwuXYMrrXQ==
+  dependencies:
+    pako "^1.0.5"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Dropzone doesn't handle TIFF images, so this is a workaround to getting TIFF thumbnails displayed.

The main idea is:

1. Convert TIFF -> PNG
2. Call `dropzone.createThumbnailFromUrl` with the converted image